### PR TITLE
Reject all stop word instances in Tokenizer.filter_out/2

### DIFF
--- a/lib/simple_bayes/tokenizer.ex
+++ b/lib/simple_bayes/tokenizer.ex
@@ -42,9 +42,12 @@ defmodule SimpleBayes.Tokenizer do
 
       iex> SimpleBayes.Tokenizer.filter_out(["foo", "bar", "baz"], ["baz", "bazz"])
       ["foo", "bar"]
+
+      iex> SimpleBayes.Tokenizer.filter_out(["foo", "bar", "baz", "baz"], ["baz"])
+      ["foo", "bar"]
   """
   def filter_out(list, filter_list) do
-    list -- filter_list
+    Enum.reject list, &(&1 in filter_list)
   end
 
   @doc """


### PR DESCRIPTION
I noticed that stop words appeared to still be surfacing in my category tokens after configuring them in my `config.exs`. I did some digging, and found this function, which appears to only filter out one instance of each stop word in the given token list. Thus I realized if I had multiple instances of the same stop word in my training text, the stop word would still be used as a token at the classification step.

I made the following correction to reject all instances of the stop words in the token list, with expected behavior demonstrated here:

```
iex(1)> ["foo", "bar", "baz", "baz"] -- ["baz"]
["foo", "bar", "baz"]
iex(2)> Enum.reject(["foo", "bar", "baz", "baz"], &(&1 in ["baz"]))
["foo", "bar"]
```
Hope this makes sense! Happy to talk more about it.